### PR TITLE
Rename symbolize_keys to recursive_symbolize_keys to allow clashing with Rails' non recursive one.

### DIFF
--- a/lib/magick_title/hash.rb
+++ b/lib/magick_title/hash.rb
@@ -6,15 +6,14 @@ end
 
 class Hash
   
-  # Stolen from rails 
-  def symbolize_keys
+  def recursive_symbolize_keys
     self.inject({}){|result, (key, value)|
       new_key = case key  
                 when String then key.to_sym  
                 else key  
                 end  
       new_value = case value
-                  when Hash then value.symbolize_keys
+                  when Hash then value.recursive_symbolize_keys
                   else value
                   end  
       result[new_key] = new_value  

--- a/lib/magick_title/image.rb
+++ b/lib/magick_title/image.rb
@@ -49,7 +49,7 @@ module MagickTitle
       @old_path = fullpath
       
       if opts.is_a? Hash
-        @options = (@options || MagickTitle.options).merge(opts.symbolize_keys)
+        @options = (@options || MagickTitle.options).merge(opts.recursive_symbolize_keys)
       elsif opts.is_a? Symbol
         @options = MagickTitle.styles[opts]
       end


### PR DESCRIPTION
This pull request fixes the issue #5 that I just reported. The same test pass before and after this commit on my machine:

``` text
Started
.....F....F............................
Finished in 3.796000 seconds.

  1) Failure:
test: Image should set a title's line-height. (TestImage) [/Users/pupeno/Documents/magick_title/test/test_image.rb:14]:
<183> expected but was
<181>.

  2) Failure:
test: an existing title should identify its dimensions and size. (TestImage) [/Users/pupeno/Documents/magick_title/test/test_image.rb:87]:
<3858> expected but was
<2746>.

39 tests, 86 assertions, 2 failures, 0 errors, 0 skips
```
